### PR TITLE
Use different method to check if an object is an observable

### DIFF
--- a/src/app/public/modules/list/helpers.spec.ts
+++ b/src/app/public/modules/list/helpers.spec.ts
@@ -1,6 +1,22 @@
+// #region imports
 import {
-  getData
+  EventEmitter
+} from '@angular/core';
+
+import {
+  Observable
+} from 'rxjs/Observable';
+
+import {
+  Subject
+} from 'rxjs/Subject';
+
+import {
+  getData,
+  isObservable
 } from './helpers';
+// #endregion
+
 describe('list helpers', () => {
   it('gets data based on a standard selector', () => {
     let data = {
@@ -66,5 +82,17 @@ describe('list helpers', () => {
     };
     let result = getData(data, '');
     expect(result).toBe(undefined);
+  });
+
+  it('should check if an object is an observable', () => {
+    const eventEmitter = new EventEmitter<void>();
+    const observable = new Observable<void>();
+    const subject = new Subject<void>();
+
+    expect(isObservable(eventEmitter)).toEqual(true);
+    expect(isObservable(observable)).toEqual(true);
+    expect(isObservable(subject)).toEqual(true);
+    expect(isObservable({})).toEqual(false);
+    expect(isObservable('foobar')).toEqual(false);
   });
 });

--- a/src/app/public/modules/list/helpers.ts
+++ b/src/app/public/modules/list/helpers.ts
@@ -1,5 +1,6 @@
-import { Observable } from 'rxjs/Observable';
-import {$$observable as symbolObservable} from 'rxjs/symbol/observable';
+import {
+  Observable
+} from 'rxjs/Observable';
 
 export function getData(item: any, selector: string): any {
   let resultFieldParts = selector.split('.');
@@ -58,5 +59,5 @@ export function compare(value1: any, value2: any) {
   https://github.com/angular/angular/commit/109f0d1
 */
 export function isObservable(obj: any | Observable<any>): obj is Observable<any> {
-  return !!(obj && obj[symbolObservable]);
+  return (obj instanceof Observable);
 }

--- a/src/app/public/modules/list/helpers.ts
+++ b/src/app/public/modules/list/helpers.ts
@@ -55,9 +55,9 @@ export function compare(value1: any, value2: any) {
 }
 
 /*
-  Taken from @angular's internal library to determine whether an object is an Obserable.
-  https://github.com/angular/angular/commit/109f0d1
+  Taken directly from rxjs's internal utility to determine whether an object is an Obserable.
+  See: https://github.com/ReactiveX/rxjs/blob/master/src/internal/util/isObservable.ts
 */
-export function isObservable(obj: any | Observable<any>): obj is Observable<any> {
-  return (obj instanceof Observable);
+export function isObservable<T>(obj: any): obj is Observable<T> {
+  return !!obj && (obj instanceof Observable || (typeof obj.lift === 'function' && typeof obj.subscribe === 'function'));
 }


### PR DESCRIPTION
This fixes the console logs we see when using RxJS 6+.