### PR TITLE
Fix race condition with paging

### DIFF
--- a/src/app/public/modules/list-paging/list-paging.component.spec.ts
+++ b/src/app/public/modules/list-paging/list-paging.component.spec.ts
@@ -1,7 +1,8 @@
 import {
   TestBed,
   async,
-  fakeAsync
+  fakeAsync,
+  tick
 } from '@angular/core/testing';
 import { DebugElement } from '@angular/core';
 import { By } from '@angular/platform-browser';
@@ -145,10 +146,13 @@ describe('List Paging Component', () => {
     });
 
     describe('component changes', () => {
-      it('dispatches set page number action when page changes from component', () => {
+      it('dispatches set page number action when page changes from component', fakeAsync(() => {
+        fixture.detectChanges();
         element.query(
           By.css(getPagingSelector('3'))
         ).triggerEventHandler('click', undefined);
+        fixture.detectChanges();
+        tick();
         fixture.detectChanges();
 
         state.take(1).subscribe(stateModel => {
@@ -156,7 +160,7 @@ describe('List Paging Component', () => {
         });
 
         fixture.detectChanges();
-      });
+      }));
     });
   });
 

--- a/src/app/public/modules/list-paging/list-paging.component.ts
+++ b/src/app/public/modules/list-paging/list-paging.component.ts
@@ -102,9 +102,13 @@ export class SkyListPagingComponent extends ListPagingComponent implements OnIni
   }
 
   public pageChange(currentPage: number) {
-    this.dispatcher.next(
-      new ListPagingSetPageNumberAction(Number(currentPage))
-    );
+    // Paging must be updated after list data has been updated.
+    // Adding a setTimeout will pull it out of the stream.
+    setTimeout(() => {
+      this.dispatcher.next(
+        new ListPagingSetPageNumberAction(Number(currentPage))
+      );
+    });
   }
 
 }


### PR DESCRIPTION
Paging needs to be updated only after items data has changed. Adding a `setTimeout` ensures that paging is checked after items.
Related pull request: https://github.com/blackbaud/skyux-list-builder-view-grids/pull/30