### PR TITLE
Fixes to original multiselect PR

### DIFF
--- a/src/app/public/modules/list-toolbar/list-multiselect-toolbar.component.ts
+++ b/src/app/public/modules/list-toolbar/list-multiselect-toolbar.component.ts
@@ -148,7 +148,7 @@ export class SkyListMultiselectToolbarComponent implements OnInit, OnDestroy {
     });
   }
 
-  private showSelectedValuesEqual(prev: ListFilterModel[], next: ListFilterModel[]) {
+  private showSelectedValuesEqual(prev: ListFilterModel[], next: ListFilterModel[]): boolean {
     const prevShowSelectedFilter = prev.find(filter => filter.name === 'show-selected');
     const nextShowSelectedFilter = next.find(filter => filter.name === 'show-selected');
 

--- a/src/app/public/modules/list-toolbar/list-toolbar.component.spec.ts
+++ b/src/app/public/modules/list-toolbar/list-toolbar.component.spec.ts
@@ -24,7 +24,8 @@ import {
 
 import {
   ListState,
-  ListStateDispatcher
+  ListStateDispatcher,
+  ListSelectedSetItemsSelectedAction
 } from '../list/state';
 
 import {
@@ -483,14 +484,15 @@ describe('List Toolbar Component', () => {
       expect(filtersUpdateSpy).not.toHaveBeenCalled();
 
       // Send selection to dispatcher and expect filter update to have NOT been called.
-      dispatcher.setSelected(['1']);
+      dispatcher.setSelected(['1'], true);
       fixture.detectChanges();
       expect(filtersUpdateSpy).not.toHaveBeenCalled();
 
       // Click "Show only selected" and send new selection to dispatcher. Expect filter update to have been called.
       clickShowOnlySelectedCheckbox();
       filtersUpdateSpy.calls.reset();
-      dispatcher.setSelected(['1', '2']);
+      // dispatcher.setSelected(['1', '2'], true);
+      dispatcher.next(new ListSelectedSetItemsSelectedAction(['1', '2'], true, false));
       fixture.detectChanges();
       expect(filtersUpdateSpy).toHaveBeenCalled();
     });
@@ -499,7 +501,7 @@ describe('List Toolbar Component', () => {
       initializeToolbarWithMultiselect();
 
       // Send selection to dispatcher and click "Show only selected".
-      dispatcher.setSelected(['1', '2']);
+      dispatcher.setSelected(['1', '2'], true);
       fixture.detectChanges();
       clickShowOnlySelectedCheckbox();
       fixture.detectChanges();
@@ -540,7 +542,7 @@ describe('List Toolbar Component', () => {
       });
 
       // Send selection to dispatcher and click "Show only selected".
-      dispatcher.setSelected(['1', '2']);
+      dispatcher.setSelected(['1', '2'], true);
       fixture.detectChanges();
       clickShowOnlySelectedCheckbox();
       fixture.detectChanges();

--- a/src/app/public/modules/list/list.component.spec.ts
+++ b/src/app/public/modules/list/list.component.spec.ts
@@ -539,7 +539,7 @@ describe('List Component', () => {
         ];
 
         // Select rows and apply "Show only selected" filter.
-        dispatcher.next(new ListSelectedSetItemsSelectedAction(['1', '2'], true));
+        dispatcher.setSelected(['1','2'], true);
         dispatcher.filtersUpdate(filters);
         fixture.detectChanges();
 
@@ -551,7 +551,7 @@ describe('List Component', () => {
         });
 
         // Change selections and disable the "Show only selected" filter.
-        dispatcher.setSelected(['1','4']);
+        dispatcher.setSelected(['4'], true);
         dispatcher.filtersUpdate([]);
         fixture.detectChanges();
 
@@ -559,7 +559,8 @@ describe('List Component', () => {
         component.list.selectedItems.take(1).subscribe((items)=> {
           expect(items.length === 2);
           expect(items[0].data.column2).toBe('Apple');
-          expect(items[1].data.column2).toBe('Carrot');
+          expect(items[1].data.column2).toBe('Banana');
+          expect(items[2].data.column2).toBe('Carrot');
         });
 
       }));
@@ -1283,7 +1284,7 @@ describe('List Component', () => {
     });
 
     it('should construct ListItemsSetSelectedAction', () => {
-      let action = new ListItemsSetSelectedAction(['1']);
+      let action = new ListItemsSetSelectedAction(['1'], true);
       expect(action).not.toBeUndefined();
     });
 

--- a/src/app/public/modules/list/state/items/items.orchestrator.ts
+++ b/src/app/public/modules/list/state/items/items.orchestrator.ts
@@ -54,10 +54,10 @@ export class ListItemsOrchestrator extends ListStateOrchestrator<AsyncList<ListI
     state: AsyncList<ListItemModel>,
     action: ListItemsSetSelectedAction
   ): AsyncList<ListItemModel> {
-    const newListItems = this.cloneListItemModelArray(state.items);
+    let newListItems = this.cloneListItemModelArray(state.items);
 
     action.items.map(s => {
-      const newItem = newListItems.find(i => i.id === s);
+      let newItem = newListItems.find(i => i.id === s);
       if (newItem) {
         newItem.isSelected = action.selected;
       }

--- a/src/app/public/modules/list/state/items/items.orchestrator.ts
+++ b/src/app/public/modules/list/state/items/items.orchestrator.ts
@@ -24,7 +24,7 @@ export class ListItemsOrchestrator extends ListStateOrchestrator<AsyncList<ListI
     this
       .register(ListItemsSetLoadingAction, this.setLoading)
       .register(ListItemsLoadAction, this.load)
-      .register(ListItemsSetSelectedAction, this.setItemsSelectedTrue);
+      .register(ListItemsSetSelectedAction, this.setItemsSelected);
   }
 
   private setLoading(
@@ -50,13 +50,17 @@ export class ListItemsOrchestrator extends ListStateOrchestrator<AsyncList<ListI
     );
   }
 
-  private setItemsSelectedTrue(
+  private setItemsSelected(
     state: AsyncList<ListItemModel>,
     action: ListItemsSetSelectedAction
   ): AsyncList<ListItemModel> {
-    const newListItems: ListItemModel[] = [];
-    state.items.map(item => {
-      newListItems.push(new ListItemModel(item.id, item.data, action.items.indexOf(item.id) > -1 ? true : false));
+    const newListItems = this.cloneListItemModelArray(state.items);
+
+    action.items.map(s => {
+      const newItem = newListItems.find(i => i.id === s);
+      if (newItem) {
+        newItem.isSelected = action.selected;
+      }
     });
 
     return new AsyncList<ListItemModel>(
@@ -65,5 +69,15 @@ export class ListItemsOrchestrator extends ListStateOrchestrator<AsyncList<ListI
       state.loading,
       state.count
     );
+  }
+
+  private cloneListItemModelArray(source: Array<ListItemModel>) {
+    let newListItems: Array<ListItemModel> = [];
+    source.forEach(item => {
+      newListItems.push(
+        new ListItemModel(item.id, Object.assign({}, item.data), item.isSelected)
+      );
+    });
+    return newListItems;
   }
 }

--- a/src/app/public/modules/list/state/items/items.spec.ts
+++ b/src/app/public/modules/list/state/items/items.spec.ts
@@ -257,31 +257,31 @@ describe('list items', () => {
 
       tick();
 
-      dispatcher.next(new ListItemsSetSelectedAction(['1', '3']));
+      dispatcher.next(new ListItemsSetSelectedAction(['1', '3'], true));
 
       tick();
 
       state.take(1).subscribe(stateModel => {
         expect(stateModel.items.items[0].isSelected).toBe(true);
-        expect(stateModel.items.items[1].isSelected).toBe(false);
+        expect(stateModel.items.items[1].isSelected).toBeUndefined();
         expect(stateModel.items.items[2].isSelected).toBe(true);
       });
 
       tick();
 
-      dispatcher.next(new ListItemsSetSelectedAction(['2', '3']));
+      dispatcher.next(new ListItemsSetSelectedAction(['2', '3'], true));
 
       tick();
 
       state.take(1).subscribe(stateModel => {
-        expect(stateModel.items.items[0].isSelected).toBe(false);
+        expect(stateModel.items.items[0].isSelected).toBe(true);
         expect(stateModel.items.items[1].isSelected).toBe(true);
         expect(stateModel.items.items[2].isSelected).toBe(true);
       });
 
       tick();
 
-      dispatcher.next(new ListItemsSetSelectedAction([]));
+      dispatcher.next(new ListItemsSetSelectedAction(['1', '2', '3'], false));
 
       tick();
 

--- a/src/app/public/modules/list/state/items/set-items-selected.action.ts
+++ b/src/app/public/modules/list/state/items/set-items-selected.action.ts
@@ -1,6 +1,7 @@
 export class ListItemsSetSelectedAction {
   constructor(
     public items: string[],
+    public selected: boolean = false,
     public refresh: boolean = true
   ) {}
 }

--- a/src/app/public/modules/list/state/list-state-action.type.ts
+++ b/src/app/public/modules/list/state/list-state-action.type.ts
@@ -34,8 +34,7 @@ import {
   ListSelectedSetLoadingAction,
   ListSelectedLoadAction,
   ListSelectedSetItemSelectedAction,
-  ListSelectedSetItemsSelectedAction,
-  ListSelectedSetItemsSelectedTrueAction
+  ListSelectedSetItemsSelectedAction
 } from './selected/actions';
 
 import {
@@ -54,6 +53,6 @@ export type ListStateAction =
   ListViewsLoadAction | ListViewsSetActiveAction | ListToolbarItemsLoadAction |
   ListToolbarSetExistsAction | ListSearchSetSearchTextAction | ListSearchSetFunctionsAction |
   ListSearchSetFieldSelectorsAction | ListSearchSetOptionsAction | ListSelectedSetLoadingAction |
-  ListSelectedLoadAction | ListSelectedSetItemSelectedAction | ListSelectedSetItemsSelectedAction | ListSelectedSetItemsSelectedTrueAction |
+  ListSelectedLoadAction | ListSelectedSetItemSelectedAction | ListSelectedSetItemsSelectedAction |
   ListToolbarSetTypeAction | ListSortSetFieldSelectorsAction | ListSortSetAvailableAction |
   ListSortSetGlobalAction | ListFiltersUpdateAction | ListToolbarItemsRemoveAction | ListToolbarItemsDisableAction;

--- a/src/app/public/modules/list/state/list-state.rxstate.ts
+++ b/src/app/public/modules/list/state/list-state.rxstate.ts
@@ -61,12 +61,9 @@ import {
 } from './filters/actions';
 
 import {
-  ListSelectedSetItemsSelectedTrueAction
-} from './selected/actions';
-
-import {
   ListItemsSetSelectedAction
 } from './items/actions';
+import { ListSelectedSetItemsSelectedAction } from './selected/actions';
 
 export class ListStateOrchestrator<T> extends StateOrchestrator<T, ListStateAction> {
 }
@@ -134,10 +131,10 @@ export class ListStateDispatcher extends StateDispatcher<ListStateAction> {
     this.next(new ListFiltersUpdateAction(filters));
   }
 
-  public setSelected(selectedIds: string[]): void {
-    // Update ListItemModel (grid).
-    this.next(new ListItemsSetSelectedAction(selectedIds, false));
+  public setSelected(selectedIds: string[], selected: boolean): void {
     // Update ListSelectedModel (checklist / select field).
-    this.next(new ListSelectedSetItemsSelectedTrueAction(selectedIds, false));
+    this.next(new ListSelectedSetItemsSelectedAction(selectedIds, selected, false));
+    // Update ListItemModel (grid).
+    this.next(new ListItemsSetSelectedAction(selectedIds, selected, false));
   }
 }

--- a/src/app/public/modules/list/state/selected/actions.ts
+++ b/src/app/public/modules/list/state/selected/actions.ts
@@ -2,4 +2,3 @@ export { ListSelectedLoadAction } from './load.action';
 export { ListSelectedSetLoadingAction } from './set-loading.action';
 export { ListSelectedSetItemSelectedAction } from './set-item-selected.action';
 export { ListSelectedSetItemsSelectedAction } from './set-items-selected.action';
-export { ListSelectedSetItemsSelectedTrueAction } from './set-items-selected-true.action';

--- a/src/app/public/modules/list/state/selected/selected.orchestrator.ts
+++ b/src/app/public/modules/list/state/selected/selected.orchestrator.ts
@@ -6,8 +6,7 @@ import {
   ListSelectedLoadAction,
   ListSelectedSetLoadingAction,
   ListSelectedSetItemSelectedAction,
-  ListSelectedSetItemsSelectedAction,
-  ListSelectedSetItemsSelectedTrueAction
+  ListSelectedSetItemsSelectedAction
 } from './actions';
 
 export class ListSelectedOrchestrator extends ListStateOrchestrator<AsyncItem<ListSelectedModel>> {
@@ -19,7 +18,6 @@ export class ListSelectedOrchestrator extends ListStateOrchestrator<AsyncItem<Li
       .register(ListSelectedSetLoadingAction, this.setLoading)
       .register(ListSelectedSetItemSelectedAction, this.setItemSelected)
       .register(ListSelectedSetItemsSelectedAction, this.setItemsSelected)
-      .register(ListSelectedSetItemsSelectedTrueAction, this.setItemsSelectedTrue)
       .register(ListSelectedLoadAction, this.load);
   }
 
@@ -48,7 +46,8 @@ export class ListSelectedOrchestrator extends ListStateOrchestrator<AsyncItem<Li
     state: AsyncItem<ListSelectedModel>,
     action: ListSelectedSetItemSelectedAction
   ): AsyncItem<ListSelectedModel> {
-    const newSelected = Object.assign({}, state.item);
+    const newSelected = this.cloneListSelectedModel(state.item);
+
     newSelected.selectedIdMap.set(action.id, action.selected);
 
     return new AsyncItem<ListSelectedModel>(newSelected, state.lastUpdate, state.loading);
@@ -58,24 +57,17 @@ export class ListSelectedOrchestrator extends ListStateOrchestrator<AsyncItem<Li
     state: AsyncItem<ListSelectedModel>,
     action: ListSelectedSetItemsSelectedAction
   ): AsyncItem<ListSelectedModel> {
-    const newSelected = action.refresh ? new ListSelectedModel() : Object.assign({}, state.item);
+    const newSelected = action.refresh ? new ListSelectedModel() : this.cloneListSelectedModel(state.item);
 
     action.items.map(s => newSelected.selectedIdMap.set(s, action.selected));
 
     return new AsyncItem<ListSelectedModel>(newSelected, state.lastUpdate, state.loading);
   }
 
-  private setItemsSelectedTrue(
-    state: AsyncItem<ListSelectedModel>,
-    action: ListSelectedSetItemsSelectedTrueAction
-  ): AsyncItem<ListSelectedModel> {
-      const newSelected = action.refresh ? new ListSelectedModel() : Object.assign({}, state.item);
+  private cloneListSelectedModel(source: ListSelectedModel) {
+    let newListItems = new ListSelectedModel();
+    newListItems.selectedIdMap = new Map<string, boolean>(source.selectedIdMap);
 
-      newSelected.selectedIdMap.forEach((value, key, map) => {
-        newSelected.selectedIdMap.set(key, action.items.indexOf(key) > -1 ? true : false);
-      });
-      action.items.map(s => newSelected.selectedIdMap.set(s, true));
-
-      return new AsyncItem<ListSelectedModel>(newSelected, state.lastUpdate, state.loading);
+    return newListItems;
   }
 }

--- a/src/app/public/modules/list/state/selected/set-items-selected-true.action.ts
+++ b/src/app/public/modules/list/state/selected/set-items-selected-true.action.ts
@@ -1,8 +1,0 @@
-// Action used to exclusively set "isSelected = true" on
-// items in the data set. All other items will be set to false.
-export class ListSelectedSetItemsSelectedTrueAction {
-  constructor(
-    public items: string[],
-    public refresh: boolean = true
-  ) {}
-}

--- a/src/app/visual/list-toolbar/list-view-isselected-visual.component.ts
+++ b/src/app/visual/list-toolbar/list-view-isselected-visual.component.ts
@@ -48,7 +48,7 @@ export class ListViewIsSelectedTestComponent extends ListViewComponent implement
 
   public setItemSelection(): void {
     const selectedItemIds = this.localItems.filter(item => item.isSelected).map(item => item.id);
-    this.dispatcher.setSelected(selectedItemIds);
+    this.dispatcher.setSelected(selectedItemIds, true);
   }
 
 }


### PR DESCRIPTION
This is a PR into my previous PR #18 to correct a few issues:

1) There was no support for list-view-checkilst's `showOnlySelected ` input property.  `list-multiselect-toolbar.component.ts` - line 68 now watches for filter changes and will show the appropriate "checked" state on the "show only selected" checkbox.

2) Discrepancies when combining searching & selecting.
**What is expected**:
End-user should be able to: 1) select "Apple" and "Banana" 2) search for "Apple" 3) once only "Apple" is shown in the list, click "Clear All" 4) The list should ONLY clear "Apple" and secretly keep "Banana" selected because it is not visible. Removing the search should show that "Banana" is still checked.
**What actually happens**:
Both "Apple" and "Banana" are unchecked.
This was happening because I was assuming you could simply tell the orchestrator only what items are selected, and then assume everything else is unselected. See old `ListSelectedSetItemsSelectedTrueAction` properties. I've now updated these actions to not only take in a list of ids, but also a boolean to specify wether or not is should be selected or unselected.
