### PR TITLE
Prevent selected orchestrator from breaking when selectedIds are undefined

### DIFF
--- a/src/app/public/modules/list-toolbar/list-multiselect-toolbar.component.ts
+++ b/src/app/public/modules/list-toolbar/list-multiselect-toolbar.component.ts
@@ -140,6 +140,7 @@ export class SkyListMultiselectToolbarComponent implements OnInit, OnDestroy {
       name: 'show-selected',
       value: isSelected.toString(),
       filterFunction: (model: ListItemModel, showOnlySelected: boolean) => {
+        /* istanbul ignore else */
         if (showOnlySelected.toString() !== false.toString()) {
           return this.selectedIdMap.get(model.id);
         }

--- a/src/app/public/modules/list/list.component.spec.ts
+++ b/src/app/public/modules/list/list.component.spec.ts
@@ -559,6 +559,36 @@ describe('List Component', () => {
         tick();
       }));
 
+      it('should handle and undefined value for selectedIds', fakeAsync(() => {
+        tick();
+        fixture.detectChanges();
+        const dispatcherSpy = spyOn(dispatcher, 'setSelected').and.callThrough();
+
+        component.selectedIds = ['3', '4']
+        tick();
+        fixture.detectChanges();
+        expect(dispatcherSpy).toHaveBeenCalledTimes(1);
+        dispatcherSpy.calls.reset();
+
+        component.selectedIds = undefined
+        tick();
+        fixture.detectChanges();
+        expect(dispatcherSpy).toHaveBeenCalledTimes(1);
+        state.take(1).subscribe((current) => {
+          const selectedIdMap = current.selected.item.selectedIdMap;
+          expect(selectedIdMap.get('1')).toBeUndefined();
+          expect(selectedIdMap.get('2')).toBeUndefined();
+          expect(selectedIdMap.get('3')).toBeUndefined();
+          expect(selectedIdMap.get('4')).toBeUndefined();
+          expect(selectedIdMap.get('5')).toBeUndefined();
+          expect(selectedIdMap.get('6')).toBeUndefined();
+          expect(selectedIdMap.get('7')).toBeUndefined();
+        });
+
+        fixture.detectChanges();
+        tick();
+      }));
+
       it('should allow users to access displayed selectedItems', fakeAsync(() => {
         tick();
         fixture.detectChanges();

--- a/src/app/public/modules/list/list.component.spec.ts
+++ b/src/app/public/modules/list/list.component.spec.ts
@@ -559,7 +559,7 @@ describe('List Component', () => {
         tick();
       }));
 
-      it('should handle and undefined value for selectedIds', fakeAsync(() => {
+      it('should handle an undefined value for selectedIds', fakeAsync(() => {
         tick();
         fixture.detectChanges();
         const dispatcherSpy = spyOn(dispatcher, 'setSelected').and.callThrough();

--- a/src/app/public/modules/list/list.component.ts
+++ b/src/app/public/modules/list/list.component.ts
@@ -257,10 +257,8 @@ export class SkyListComponent implements AfterContentInit, OnChanges, OnDestroy 
     if (changes['selectedIds']) {
       // Only send selection changes to dispatcher if changes are distinct.
       const newSelectedIds = changes['selectedIds'].currentValue;
-      if (newSelectedIds !== this.lastSelectedIds) {
-        if (!this.arraysEqual(newSelectedIds, this.lastSelectedIds)) {
-          this.dispatcher.setSelected(newSelectedIds, true, true);
-        }
+      if (!this.arraysEqual(newSelectedIds, this.lastSelectedIds)) {
+        this.dispatcher.setSelected(newSelectedIds, true, true);
       }
     }
   }
@@ -403,6 +401,7 @@ export class SkyListComponent implements AfterContentInit, OnChanges, OnDestroy 
   }
 
   private arraysEqual(arrayA: any[], arrayB: any[]): boolean {
+    /* istanbul ignore next */
     if (arrayA === arrayB) {
       return true;
     }

--- a/src/app/public/modules/list/list.component.ts
+++ b/src/app/public/modules/list/list.component.ts
@@ -254,12 +254,12 @@ export class SkyListComponent implements AfterContentInit, OnChanges, OnDestroy 
       this.dispatcher.filtersUpdate(this.appliedFilters);
     }
     if (changes['selectedIds']) {
+      // Only send selection changes to dispatcher if changes are distinct.
       const newSelectedIds = changes['selectedIds'].currentValue;
-      const newSelectedIdsDistinct = this.lastSelectedIds && !this.arraysEqual(newSelectedIds, this.lastSelectedIds);
-
-      // Only send selection changes to the dispatcher if this is the first change or the changes are distinct.
-      if (!this.lastSelectedIds || newSelectedIdsDistinct) {
-        this.dispatcher.setSelected(newSelectedIds, true, true);
+      if (newSelectedIds !== this.lastSelectedIds) {
+        if (!this.arraysEqual(newSelectedIds, this.lastSelectedIds)) {
+          this.dispatcher.setSelected(newSelectedIds, true, true);
+        }
       }
     }
   }
@@ -402,8 +402,22 @@ export class SkyListComponent implements AfterContentInit, OnChanges, OnDestroy 
   }
 
   private arraysEqual(arrayA: any[], arrayB: any[]): boolean {
-    return arrayA.length === arrayB.length &&
-      arrayA.every((value, index) =>
-        value === arrayB[index]);
+    if (arrayA === arrayB) {
+      return true;
+    }
+    if (arrayA === undefined || arrayB === undefined) {
+      return false;
+    }
+    if (arrayA.length !== arrayB.length) {
+      return false;
+    }
+    for (let i = 0; i < arrayA.length; ++i) {
+      if (arrayA[i] !== arrayB[i]) {
+        return false;
+      }
+    }
+    return true;
   }
 }
+
+// TODO: Also, it should never call setselected with undefined items!

--- a/src/app/public/modules/list/list.component.ts
+++ b/src/app/public/modules/list/list.component.ts
@@ -160,7 +160,7 @@ export class SkyListComponent implements AfterContentInit, OnChanges, OnDestroy 
   @ContentChildren(ListViewComponent)
   private listViews: QueryList<ListViewComponent>;
 
-  private lastSelectedIds: string[];
+  private lastSelectedIds: string[] = [];
 
   private lastFilters: ListFilterModel[] = [];
 
@@ -211,7 +211,6 @@ export class SkyListComponent implements AfterContentInit, OnChanges, OnDestroy 
     this.state.map(current => current.selected)
       .takeUntil(this.ngUnsubscribe)
       .distinctUntilChanged()
-      .skip(1)
       .subscribe(selected => {
 
         // Update lastSelectedIds to help us retain user selections.
@@ -221,12 +220,14 @@ export class SkyListComponent implements AfterContentInit, OnChanges, OnDestroy 
             selectedIdsList.push(key);
           }
         });
-        this.lastSelectedIds = selectedIdsList;
 
-        // Emit new selected items if there is an observer.
-        if (this.selectedIdsChange.observers.length > 0) {
+        // If changes are distinct, emit selectedIdsChange.
+        const distinctChanges = !this.arraysEqual(this.lastSelectedIds, selectedIdsList);
+        if (this.selectedIdsChange.observers.length > 0 && distinctChanges) {
           this.selectedIdsChange.emit(selected.item.selectedIdMap);
         }
+
+        this.lastSelectedIds = selectedIdsList;
       });
 
     if (this.appliedFiltersChange.observers.length > 0) {

--- a/src/app/public/modules/list/list.component.ts
+++ b/src/app/public/modules/list/list.component.ts
@@ -390,7 +390,7 @@ export class SkyListComponent implements AfterContentInit, OnChanges, OnDestroy 
   }
 
   private getItemsAndRetainSelections(newList: ListItemModel[], selectedIds: string[]): ListItemModel[] {
-    if (!selectedIds) {
+    if (selectedIds.length === 0) {
       return newList;
     }
     let updatedListModel = newList.slice();

--- a/src/app/public/modules/list/list.component.ts
+++ b/src/app/public/modules/list/list.component.ts
@@ -420,5 +420,3 @@ export class SkyListComponent implements AfterContentInit, OnChanges, OnDestroy 
     return true;
   }
 }
-
-// TODO: Also, it should never call setselected with undefined items!

--- a/src/app/public/modules/list/state/items/items.orchestrator.ts
+++ b/src/app/public/modules/list/state/items/items.orchestrator.ts
@@ -54,21 +54,22 @@ export class ListItemsOrchestrator extends ListStateOrchestrator<AsyncList<ListI
     state: AsyncList<ListItemModel>,
     action: ListItemsSetSelectedAction
   ): AsyncList<ListItemModel> {
-    let newListItems = this.cloneListItemModelArray(state.items);
+    const newSelectedIds = action.items || [];
+    let newListItemModels = this.cloneListItemModelArray(state.items);
 
     if (action.refresh) {
-      newListItems.forEach(item => item.isSelected = undefined);
+      newListItemModels.forEach(item => item.isSelected = undefined);
     }
 
-    action.items.map(s => {
-      let newItem = newListItems.find(i => i.id === s);
+    newSelectedIds.map(s => {
+      let newItem = newListItemModels.find(i => i.id === s);
       if (newItem) {
         newItem.isSelected = action.selected;
       }
     });
 
     return new AsyncList<ListItemModel>(
-      newListItems,
+      newListItemModels,
       Date.now(),
       state.loading,
       state.count

--- a/src/app/public/modules/list/state/list-state.rxstate.ts
+++ b/src/app/public/modules/list/state/list-state.rxstate.ts
@@ -134,7 +134,7 @@ export class ListStateDispatcher extends StateDispatcher<ListStateAction> {
     this.next(new ListFiltersUpdateAction(filters));
   }
 
-  public setSelected(selectedIds: string[] = [], selected: boolean, refresh: boolean = false): void {
+  public setSelected(selectedIds: string[], selected: boolean, refresh: boolean = false): void {
     // Update ListSelectedModel (checklist / select field).
     this.next(new ListSelectedSetItemsSelectedAction(selectedIds, selected, refresh));
     // Update ListItemModel (grid).

--- a/src/app/public/modules/list/state/list-state.rxstate.ts
+++ b/src/app/public/modules/list/state/list-state.rxstate.ts
@@ -134,7 +134,7 @@ export class ListStateDispatcher extends StateDispatcher<ListStateAction> {
     this.next(new ListFiltersUpdateAction(filters));
   }
 
-  public setSelected(selectedIds: string[], selected: boolean, refresh: boolean = false): void {
+  public setSelected(selectedIds: string[] = [], selected: boolean, refresh: boolean = false): void {
     // Update ListSelectedModel (checklist / select field).
     this.next(new ListSelectedSetItemsSelectedAction(selectedIds, selected, refresh));
     // Update ListItemModel (grid).

--- a/src/app/public/modules/list/state/selected/selected.orchestrator.ts
+++ b/src/app/public/modules/list/state/selected/selected.orchestrator.ts
@@ -57,11 +57,12 @@ export class ListSelectedOrchestrator extends ListStateOrchestrator<AsyncItem<Li
     state: AsyncItem<ListSelectedModel>,
     action: ListSelectedSetItemsSelectedAction
   ): AsyncItem<ListSelectedModel> {
-    const newSelected = action.refresh ? new ListSelectedModel() : this.cloneListSelectedModel(state.item);
+    const newSelectedIds = action.items || [];
+    const newListSelectedModel = action.refresh ? new ListSelectedModel() : this.cloneListSelectedModel(state.item);
 
-    action.items.map(s => newSelected.selectedIdMap.set(s, action.selected));
+    newSelectedIds.map(s => newListSelectedModel.selectedIdMap.set(s, action.selected));
 
-    return new AsyncItem<ListSelectedModel>(newSelected, state.lastUpdate, state.loading);
+    return new AsyncItem<ListSelectedModel>(newListSelectedModel, state.lastUpdate, state.loading);
   }
 
   private cloneListSelectedModel(source: ListSelectedModel) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "./node_modules/@skyux-sdk/builder/tsconfig",
   "compilerOptions": {
-    "experimentalDecorators": true,
     "module": "commonjs"
   },
   "exclude": [


### PR DESCRIPTION
Also added some better comparison for arrays. Previously, the comparison wasn't handling undefined values.