### PR TITLE
Dispatcher no longer updates ListItemModel

### DIFF
--- a/src/app/public/modules/list/state/list-state.rxstate.ts
+++ b/src/app/public/modules/list/state/list-state.rxstate.ts
@@ -20,10 +20,6 @@ import {
 } from './filters/actions';
 
 import {
-  ListItemsSetSelectedAction
-} from './items/actions';
-
-import {
   ListStateAction
 } from './list-state-action.type';
 

--- a/src/app/public/modules/list/state/list-state.rxstate.ts
+++ b/src/app/public/modules/list/state/list-state.rxstate.ts
@@ -135,9 +135,6 @@ export class ListStateDispatcher extends StateDispatcher<ListStateAction> {
   }
 
   public setSelected(selectedIds: string[], selected: boolean, refresh: boolean = false): void {
-    // Update ListSelectedModel (checklist / select field).
     this.next(new ListSelectedSetItemsSelectedAction(selectedIds, selected, refresh));
-    // Update ListItemModel (grid).
-    this.next(new ListItemsSetSelectedAction(selectedIds, selected, refresh));
   }
 }


### PR DESCRIPTION
Addresses blackbaud/skyux-list-builder-view-grids#58

**Some background:**
When multiselect was introduced, the checkboxes needed to be bound to something that was common across both grid flavors (`skyux-grids` and `list-builder-view-grids`). [We added the `isSelected` boolean to the `ListItemModel`](https://github.com/blackbaud/skyux-list-builder-common/blob/master/src/app/public/state/items/item.model.ts#L4) to solve this. The dispatcher would not only update the list state's [`ListSelectedModel`](https://github.com/blackbaud/skyux-list-builder/blob/master/src/app/public/modules/list/state/selected/selected.model.ts#L1), but now would also update `ListItemModel.isSelected`. It was a quick and easy way to ensure both grid's selected states were in sync.

Since this change we started to see some performance issues when the grid had multiple components in a row (dropdown, checkbox, etc...), or when the grid had many rows of data. Because the selection state was tied to the `ListItemModel`, it was [triggering a full rebuild of the grid's data every time a selection was made](https://github.com/blackbaud/skyux-grids/blob/master/src/app/public/modules/grid/grid.component.ts#L303).

Fast forward a bit and consumers started to ask for a way to programmatically set selections on the `skyux-grid` component. To remedy this, we added a [`setSelectedId` input](https://github.com/blackbaud/skyux-grids/blob/master/src/app/public/modules/grid/grid.component.ts#L188) to the grid component. We also found that this was a much more performant way to update the checkboxes when items were selected. That brings us to where we are today - there's no longer a need to update the `ListItemModel.isSelected` property from the dispatcher because the addition of this new input property handles the conversion from its own array of id's to the `ListItemModel.isSelected` (see the `applySelectedRows` method). Hence, we should remove this redundant and unnecessary call to update `ListItemModel.isSelected`.