### PR TITLE
Added property to disable searching against in-memory data

### DIFF
--- a/src/app/public/modules/list-toolbar/fixtures/list-toolbar.component.fixture.html
+++ b/src/app/public/modules/list-toolbar/fixtures/list-toolbar.component.fixture.html
@@ -4,7 +4,6 @@
   [searchText]="searchText"
   [sortSelectorEnabled]="sortEnabled"
   [toolbarType]="toolbarType"
-  (searchApplied)="onSearchApplied($event)"
   #toolbar
 >
   <sky-list-toolbar-item *ngIf="showCutomItem1"

--- a/src/app/public/modules/list-toolbar/fixtures/list-toolbar.component.fixture.html
+++ b/src/app/public/modules/list-toolbar/fixtures/list-toolbar.component.fixture.html
@@ -1,9 +1,12 @@
 <sky-list-toolbar
+  [inMemorySearchEnabled]="inMemorySearchEnabled"
   [searchEnabled]="searchEnabled"
-  [sortSelectorEnabled]="sortEnabled"
   [searchText]="searchText"
+  [sortSelectorEnabled]="sortEnabled"
   [toolbarType]="toolbarType"
-  #toolbar>
+  (searchApplied)="onSearchApplied($event)"
+  #toolbar
+>
   <sky-list-toolbar-item *ngIf="showCutomItem1"
     id="custom-item"
     location="right"

--- a/src/app/public/modules/list-toolbar/fixtures/list-toolbar.component.fixture.ts
+++ b/src/app/public/modules/list-toolbar/fixtures/list-toolbar.component.fixture.ts
@@ -25,6 +25,4 @@ import {
 
   @ViewChild('default')
   public default: TemplateRef<any>;
-
-  public onSearchApplied(searchText: string): void {}
 }

--- a/src/app/public/modules/list-toolbar/fixtures/list-toolbar.component.fixture.ts
+++ b/src/app/public/modules/list-toolbar/fixtures/list-toolbar.component.fixture.ts
@@ -13,6 +13,7 @@ import {
    templateUrl: './list-toolbar.component.fixture.html'
  })
  export class ListToolbarTestComponent {
+  public inMemorySearchEnabled: boolean;
   public toolbarType: string;
   public searchEnabled: boolean;
   public sortEnabled: boolean;
@@ -24,4 +25,6 @@ import {
 
   @ViewChild('default')
   public default: TemplateRef<any>;
+
+  public onSearchApplied(searchText: string): void {}
 }

--- a/src/app/public/modules/list-toolbar/list-toolbar.component.spec.ts
+++ b/src/app/public/modules/list-toolbar/list-toolbar.component.spec.ts
@@ -228,7 +228,7 @@ describe('List Toolbar Component', () => {
       initializeToolbar();
       fixture.whenStable().then(() => {
         fixture.detectChanges();
-        const spy = spyOn(component, 'onSearchApplied').and.callThrough();
+        const spy = spyOn(component.toolbar.searchApplied, 'next').and.callThrough();
 
         component.toolbar.searchComponent.applySearchText('something');
         fixture.detectChanges();

--- a/src/app/public/modules/list-toolbar/list-toolbar.component.spec.ts
+++ b/src/app/public/modules/list-toolbar/list-toolbar.component.spec.ts
@@ -78,6 +78,7 @@ describe('List Toolbar Component', () => {
     component = fixture.componentInstance;
   });
 
+  // #region helpers
   function initializeToolbar() {
     fixture.detectChanges();
     // always skip the first update to ListState, when state is ready
@@ -138,6 +139,7 @@ describe('List Toolbar Component', () => {
     expect(items.item(2)).toHaveText('Custom Item');
     expect(items.item(3)).toHaveText('Custom Item 2');
   }
+  // #endregion
 
   describe('search', () => {
     it('should be visible by default', async(() => {
@@ -219,6 +221,62 @@ describe('List Toolbar Component', () => {
           });
           fixture.detectChanges();
         });
+      });
+    }));
+
+    it('should emit a value on the searchApplied property when a search is applied', async(() => {
+      initializeToolbar();
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+        const spy = spyOn(component, 'onSearchApplied').and.callThrough();
+
+        component.toolbar.searchComponent.applySearchText('something');
+        fixture.detectChanges();
+
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith('something');
+      });
+    }));
+
+    it('should call list state dispatcher when inMemorySearchEnabled is undefined', async(() => {
+      component.inMemorySearchEnabled = undefined;
+      initializeToolbar();
+      const setTextSpy = spyOn(dispatcher, 'searchSetText').and.callThrough();
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+
+        component.toolbar.searchComponent.applySearchText('something');
+        fixture.detectChanges();
+
+        expect(setTextSpy).toHaveBeenCalledTimes(1);
+      });
+    }));
+
+    it('should call list state dispatcher when inMemorySearchEnabled is true', async(() => {
+      component.inMemorySearchEnabled = true;
+      initializeToolbar();
+      const setTextSpy = spyOn(dispatcher, 'searchSetText').and.callThrough();
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+
+        component.toolbar.searchComponent.applySearchText('something');
+        fixture.detectChanges();
+
+        expect(setTextSpy).toHaveBeenCalledTimes(1);
+      });
+    }));
+
+    it('should not call list state dispatcher when inMemorySearchEnabled is false', async(() => {
+      component.inMemorySearchEnabled = false;
+      initializeToolbar();
+      const setTextSpy = spyOn(dispatcher, 'searchSetText').and.callThrough();
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+
+        component.toolbar.searchComponent.applySearchText('something');
+        fixture.detectChanges();
+
+        expect(setTextSpy).not.toHaveBeenCalledTimes(1);
       });
     }));
   });

--- a/src/app/public/modules/list-toolbar/list-toolbar.component.ts
+++ b/src/app/public/modules/list-toolbar/list-toolbar.component.ts
@@ -404,6 +404,7 @@ export class SkyListToolbarComponent implements OnInit, AfterContentInit, OnDest
   }
 
   public ngOnDestroy() {
+    this.searchApplied.complete();
     this.ngUnsubscribe.next();
     this.ngUnsubscribe.complete();
   }

--- a/src/app/public/modules/list-toolbar/list-toolbar.component.ts
+++ b/src/app/public/modules/list-toolbar/list-toolbar.component.ts
@@ -93,6 +93,13 @@ let nextId = 0;
 })
 export class SkyListToolbarComponent implements OnInit, AfterContentInit, OnDestroy {
 
+  /**
+   * Indicates whether to use the in-memory search.
+   * Setting this to `false` will allow consumers to run their own searches remotely,
+   * and push new values to the list component by updating the `data` property.
+   * @default true
+   * @internal
+   */
   @Input()
   public set inMemorySearchEnabled(value: boolean) {
     this._inMemorySearchEnabled = value;
@@ -123,6 +130,10 @@ export class SkyListToolbarComponent implements OnInit, AfterContentInit, OnDest
   @Input()
   public searchText: string | Observable<string>;
 
+  /**
+   * Fires when users submit a search.
+   * @internal
+   */
   @Output()
   public searchApplied: EventEmitter<string> = new EventEmitter<string>();
 

--- a/src/app/public/modules/list-toolbar/list-toolbar.component.ts
+++ b/src/app/public/modules/list-toolbar/list-toolbar.component.ts
@@ -4,11 +4,9 @@ import {
   ChangeDetectorRef,
   Component,
   ContentChildren,
-  EventEmitter,
   Input,
   OnDestroy,
   OnInit,
-  Output,
   QueryList,
   TemplateRef,
   ViewChild
@@ -130,13 +128,6 @@ export class SkyListToolbarComponent implements OnInit, AfterContentInit, OnDest
   @Input()
   public searchText: string | Observable<string>;
 
-  /**
-   * Fires when users submit a search.
-   * @internal
-   */
-  @Output()
-  public searchApplied: EventEmitter<string> = new EventEmitter<string>();
-
   public get isFilterBarDisplayed(): boolean {
     return !this.isToolbarDisabled && this.hasInlineFilters && this.inlineFilterBarExpanded;
   }
@@ -166,6 +157,12 @@ export class SkyListToolbarComponent implements OnInit, AfterContentInit, OnDest
 
   public filterButtonId: string = `sky-list-toolbar-filter-button-${++nextId}`;
   public listFilterInlineId: string = `sky-list-toolbar-filter-inline-${++nextId}`;
+
+  /**
+   * Fires when users submit a search.
+   * @internal
+   */
+  public searchApplied: Subject<string> = new Subject<string>();
 
   @ContentChildren(SkyListToolbarItemComponent)
   private toolbarItems: QueryList<SkyListToolbarItemComponent>;
@@ -431,7 +428,7 @@ export class SkyListToolbarComponent implements OnInit, AfterContentInit, OnDest
   }
 
   public updateSearchText(searchText: string) {
-    this.searchApplied.emit(searchText);
+    this.searchApplied.next(searchText);
     if (this.inMemorySearchEnabled) {
       this.state.take(1).subscribe((currentState) => {
         if (currentState.paging.pageNumber && currentState.paging.pageNumber !== 1) {


### PR DESCRIPTION
This will allow consuming components to search against remote sources in scenarios where they can't use a data provider (select field).

Addresses blackbaud/skyux-select-field#16